### PR TITLE
[CASH-535] Change redirections

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -76,7 +76,7 @@ module Spree
     end
 
     def cancel
-      redirect_to checkout_state_path(current_order.state)
+      redirect_to "/purchase"
     end
 
     private

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
       if !params[:checkout_token]
         flash[:notice] = "Invalid order confirmation data."
-        return redirect_to checkout_state_path(current_order.state)
+        return redirect_to "/purchase"
       end
 
       if order.complete?
@@ -71,7 +71,7 @@ module Spree
         flash[:order_completed] = true
         redirect_to completion_route order
       else
-        redirect_to checkout_state_path(order.state)
+        redirect_to "/purchase"
       end
     end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -1,5 +1,6 @@
 module Spree
   class AffirmController < Spree::StoreController
+    PURCHASE_PATH = "/purchase"
     helper 'spree/orders'
 
     #the confirm will do it's own protection by making calls to affirm
@@ -10,7 +11,7 @@ module Spree
 
       if !params[:checkout_token]
         flash[:notice] = "Invalid order confirmation data."
-        return redirect_to "/purchase"
+        return redirect_to PURCHASE_PATH
       end
 
       if order.complete?
@@ -71,12 +72,12 @@ module Spree
         flash[:order_completed] = true
         redirect_to completion_route order
       else
-        redirect_to "/purchase"
+        redirect_to PURCHASE_PATH
       end
     end
 
     def cancel
-      redirect_to "/purchase"
+      redirect_to PURCHASE_PATH
     end
 
     private

--- a/spec/controllers/affirm_controller_spec.rb
+++ b/spec/controllers/affirm_controller_spec.rb
@@ -89,7 +89,7 @@ describe Spree::AffirmController do
       context "when no checkout_token is provided" do
         it "redirects to the current order state" do
           post_request(nil, nil)
-          expect(response).to redirect_to("/purchase")
+          expect(response).to redirect_to(Spree::AffirmController::PURCHASE_PATH)
         end
       end
 
@@ -215,7 +215,7 @@ describe Spree::AffirmController do
     context "when the checkout has been cancelled" do
       before { get :cancel, use_route: "spree" }
       it "redirects to the purchase path" do
-        expect(response).to redirect_to("/purchase")
+        expect(response).to redirect_to(Spree::AffirmController::PURCHASE_PATH)
       end
     end
   end

--- a/spec/controllers/affirm_controller_spec.rb
+++ b/spec/controllers/affirm_controller_spec.rb
@@ -205,4 +205,18 @@ describe Spree::AffirmController do
       end
     end
   end
+
+  describe "GET cancel" do
+    before do
+      controller.stub authenticate_spree_user!: true
+      controller.stub spree_current_user: user
+    end
+
+    context "when the checkout has been cancelled" do
+      before { get :cancel, use_route: "spree" }
+      it "redirects to the purchase path" do
+        expect(response).to redirect_to("/purchase")
+      end
+    end
+  end
 end

--- a/spec/controllers/affirm_controller_spec.rb
+++ b/spec/controllers/affirm_controller_spec.rb
@@ -89,7 +89,7 @@ describe Spree::AffirmController do
       context "when no checkout_token is provided" do
         it "redirects to the current order state" do
           post_request(nil, nil)
-          expect(response).to redirect_to(controller.checkout_state_path(checkout.order.state))
+          expect(response).to redirect_to("/purchase")
         end
       end
 


### PR DESCRIPTION
### What
[CASH-535]
I changed redirections from `checkout_state_path` to `/purchase`

### Why
We use the new Single Page Checkout and it requires new redirection logic.


[CASH-535]: https://framebridge.atlassian.net/browse/CASH-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ