### PR TITLE
[CASH-535] Remove billing address

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -29,21 +29,11 @@ module Spree
 
         _affirm_checkout.errors.each do |field, error|
           case field
-          when :billing_address
-            # FIXME(brian): pass the phone number to the |order| in a better place
-            phone = order.bill_address.phone
-            order.bill_address = generate_spree_address(_affirm_checkout.details['billing'])
-            order.bill_address.phone = phone
-
           when :shipping_address
             # FIXME(brian): pass the phone number to the |order| in a better place
             phone = order.shipping_address.phone
             order.ship_address = generate_spree_address(_affirm_checkout.details['shipping'])
             order.ship_address.phone = phone
-
-          when :billing_email
-            order.email = _affirm_checkout.details["billing"]["email"]
-
           end
         end
 

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -20,8 +20,6 @@ module Spree
 
       check_valid_products
       check_matching_shipping_address
-      check_matching_billing_address
-      check_matching_billing_email
     end
 
     def check_valid_products
@@ -51,13 +49,6 @@ module Spree
       true
     end
 
-    def check_matching_billing_address
-      # ensure we have a standardized address format
-      details['billing']['address'] = normalize_affirm_address details['billing']['address']
-
-      # validate address
-      check_address_match details["billing"], order.bill_address, :billing_address
-    end
 
     def check_matching_shipping_address
       # ensure we have a standardized address format
@@ -65,12 +56,6 @@ module Spree
 
       # validate address
       check_address_match details["shipping"], order.ship_address, :shipping_address
-    end
-
-    def check_matching_billing_email
-      if details["billing"]["email"].present? and details["billing"]["email"].casecmp(order.email) != 0
-        errors.add :billing_email, "Billing email mismatch"
-      end
     end
 
     def actions

--- a/app/views/spree/checkout/payment/_affirm.html.erb
+++ b/app/views/spree/checkout/payment/_affirm.html.erb
@@ -42,22 +42,6 @@
         }
       },
 
-      billing: {
-        email: "<%= @order.email %>",
-        name: {
-          full:   "<%= @order.bill_address.full_name %>"
-        },
-        address: {
-          line1:          "<%= @order.bill_address.address1 %>",
-          line2:          "<%= @order.bill_address.address2 %>",
-          city:           "<%= @order.bill_address.city %>",
-          state:          "<%= @order.bill_address.state_text %>",
-          country:        "<%= @order.bill_address.country.iso %>",
-          zipcode:        "<%= @order.bill_address.zipcode %>",
-        }
-      },
-
-
       metadata: {
             "platform_type": "Spree Commerce",
             "platform_version": "<%= Spree.version %>",
@@ -86,9 +70,7 @@
         user_cancel_url:          "<%= cancel_affirm_url(:payment_method_id => payment_method.id) %>",
       },
 
-      config: {
-        required_billing_fields:      "name,address,email",
-      },
+      config: {},
 
 
       <% if @order.promotions.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,6 @@ en:
         "Line Item not in checkout details": "Line Item not in checkout details"
         "Quantity mismatch": "Quantity mismatch"
         "Price mismatch": "Price mismatch"
-        "Billing email mismatch": "Billing email mismatch"
         "city mismatch": "city mismatch"
         "street1 mismatch": "street1 mismatch"
         "street2 mismatch": "street2 mismatch"
@@ -23,7 +22,4 @@ en:
     attributes:
       "spree/affirm_checkout":
         line_items: "items"
-        billing_address: "billing address"
         shipping_address: "shipping address"
-        billing_email: "email"
-

--- a/lib/spree_affirm/factories/affirm_checkout_factory.rb
+++ b/lib/spree_affirm/factories/affirm_checkout_factory.rb
@@ -7,24 +7,6 @@ def BASE_CHECKOUT_DETAILS
       "name"=> "Test Merchant"
     },
     "tax_amount"=> 0,
-    "billing"=> {
-      "address"=> {
-        "city"=> "San Francisco",
-        "street1"=> "12345 Main",
-        "street2"=> "300",
-        "region1_code"=> "AL",
-        "postal_code"=> "55555",
-        "country_code"=> "USA",
-        "for_billing"=> true,
-        "validation_source"=> 3
-      },
-      "email"=> "test@affirm.com",
-      "name"=> {
-        "for_billing"=> true,
-        "last"=> "Doe",
-        "first"=> "John"
-      }
-    },
     "items"=> {
       "xxx-xx-xxx-x"=> {
         "sku"=> "xxx-xx-xxx-x",
@@ -61,13 +43,7 @@ def BASE_CHECKOUT_DETAILS
     "discount_code"=> "",
     "misc_fee_amount"=> 0,
     "shipping_type"=> "Free National UPS",
-    "config"=> {
-      "required_billing_fields"=> [
-        "name",
-        "address",
-        "email"
-      ]
-    },
+    "config"=> {},
     "api_version"=> "v2",
     "shipping_amount"=> 0
   }
@@ -83,28 +59,15 @@ FactoryGirl.define do
     transient do
       stub_details true
       shipping_address_mismatch false
-      billing_address_mismatch false
-      alternate_billing_address_format false
-      billing_address_full_name false
-      billing_email_mismatch false
       extra_line_item false
       missing_line_item false
       quantity_mismatch false
       price_mismatch false
-      full_name_case_mismatch false
     end
 
     after(:build) do |checkout, evaluator|
 
       _details = BASE_CHECKOUT_DETAILS()
-
-      # case mismatch
-      unless evaluator.full_name_case_mismatch
-        _details['billing']['name'] = {
-          "full" => checkout.order.bill_address.firstname.upcase + " " +
-                    checkout.order.bill_address.lastname.upcase
-        }
-      end
 
       # shipping address
       unless evaluator.shipping_address_mismatch
@@ -122,50 +85,6 @@ FactoryGirl.define do
             "country_code"=> checkout.order.ship_address.country.iso3
           }
         }
-      end
-
-      # billing address
-      unless evaluator.billing_address_mismatch
-        _details["billing"] = {
-          "email" => "joe@schmoe.com",
-          "name" => {
-            "first" => checkout.order.bill_address.firstname,
-            "last"  => checkout.order.bill_address.lastname
-          },
-          "address"=> {
-            "city"=> checkout.order.bill_address.city,
-            "street1"=> checkout.order.bill_address.address1,
-            "street2"=> checkout.order.bill_address.address2,
-            "region1_code"=> checkout.order.bill_address.state.abbr,
-            "postal_code"=> checkout.order.bill_address.zipcode,
-            "country_code"=> checkout.order.bill_address.country.iso3
-          }
-        }
-      end
-
-      # use alternate format for billing address
-      if evaluator.alternate_billing_address_format
-        _details['billing']["address"] = {
-          "city" => _details['billing']["address"]["city"],
-          "line1"=> _details['billing']["address"]["street1"],
-          "line2"=> _details['billing']["address"]["street2"],
-          "state"=> _details['billing']["address"]["postal_code"],
-          "zipcode"=> _details['billing']["address"]["region1_code"],
-          "country"=> _details['billing']["address"]["country_code"]
-        }
-      end
-
-      # use name.full instead of first/last
-      if evaluator.billing_address_full_name
-        _details['billing']['name'] = {
-          'full' => "#{_details['billing']['name']['first']} #{_details['billing']['name']['last']}"
-        }
-      end
-
-
-      # billing email
-      unless evaluator.billing_email_mismatch
-        _details["billing"]["email"] = checkout.order.email
       end
 
       # setup items in cart

--- a/spec/controllers/affirm_controller_spec.rb
+++ b/spec/controllers/affirm_controller_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 describe Spree::AffirmController do
   let(:user) { FactoryGirl.create(:user) }
   let(:checkout) { FactoryGirl.build(:affirm_checkout) }
-  let(:bad_billing_checkout) { FactoryGirl.build(:affirm_checkout, billing_address_mismatch: true) }
   let(:bad_shipping_checkout) { FactoryGirl.build(:affirm_checkout, shipping_address_mismatch: true) }
-  let(:bad_email_checkout) { FactoryGirl.build(:affirm_checkout, billing_email_mismatch: true) }
-
 
   describe "POST confirm" do
 
@@ -140,24 +137,6 @@ describe Spree::AffirmController do
 
     end
 
-    context "when the billing_address does not match the order" do
-      before do
-        Spree::AffirmCheckout.stub new: bad_billing_checkout
-        state = FactoryGirl.create(:state, abbr: bad_billing_checkout.details['billing']['address']['region1_code'])
-        Spree::State.stub find_by_abbr: state, find_by_name: state
-        controller.stub current_order: bad_billing_checkout.order
-      end
-
-      it "creates a new address record for the order" do
-        _old_billing_address = bad_billing_checkout.order.bill_address
-        post_request '12345789', bad_billing_checkout.payment_method.id
-
-        expect(bad_billing_checkout.order.bill_address).not_to be(_old_billing_address)
-        expect(bad_billing_checkout.valid?).to be(true)
-      end
-    end
-
-
     context "when the shipping_address does not match the order" do
       before do
         Spree::AffirmCheckout.stub new: bad_shipping_checkout
@@ -174,24 +153,6 @@ describe Spree::AffirmController do
         expect(bad_shipping_checkout.valid?).to be(true)
       end
     end
-
-
-
-    context "when the billing_email does not match the order" do
-      before do
-        Spree::AffirmCheckout.stub new: bad_email_checkout
-        controller.stub current_order: bad_email_checkout.order
-      end
-
-      it "updates the billing_email on the order" do
-        _old_email = bad_email_checkout.order.email
-        post_request '12345789', bad_email_checkout.payment_method.id
-
-        expect(bad_email_checkout.order.email).not_to be(_old_email)
-        expect(bad_email_checkout.valid?).to be(true)
-      end
-    end
-
 
     context "there is no current order" do
       before(:each) do

--- a/spec/models/spree_affirm_checkout_spec.rb
+++ b/spec/models/spree_affirm_checkout_spec.rb
@@ -45,13 +45,6 @@ describe Spree::AffirmCheckout do
         valid_checkout.check_valid_products
         expect(valid_checkout.errors.size).to be(0)
       end
-
-      it "does not throw an error for case senstive name mismatches" do
-        _checkout = FactoryGirl.build(:affirm_checkout, full_name_case_mismatch: true)
-        _checkout.check_matching_billing_address
-        expect(_checkout.errors.size).to be(0)
-
-      end
     end
 
     context "with an extra product is in the checkout details" do
@@ -86,62 +79,7 @@ describe Spree::AffirmCheckout do
         expect(_checkout.errors.size).to be(1)
       end
     end
-
   end
-
-  describe "#check_matching_billing_address" do
-    context "with a matching billing address" do
-      it "does not set any errors for the billing_address" do
-        valid_checkout.check_matching_billing_address
-        expect(valid_checkout.errors.size).to be(0)
-        expect(valid_checkout.errors[:billing_address]).to be_empty
-      end
-
-      context "with alternate address format" do
-        it "does not set any errors for the billing_address" do
-          _checkout = FactoryGirl.build(:affirm_checkout, alternate_billing_address_format: true)
-          valid_checkout.check_matching_billing_address
-          expect(valid_checkout.errors.size).to be(0)
-          expect(valid_checkout.errors[:billing_address]).to be_empty
-        end
-      end
-
-      context "with a name.full instead of first/last" do
-        it "does not set any error for the billing_address" do
-          _checkout = FactoryGirl.build(:affirm_checkout, billing_address_full_name: true)
-          _checkout.check_matching_billing_address
-          expect(_checkout.errors[:billing_address]).to be_empty
-        end
-      end
-    end
-
-    context "with a mismtached billing address" do
-      it "sets an error for the billing_address" do
-        _checkout = FactoryGirl.build(:affirm_checkout, billing_address_mismatch: true)
-        _checkout.check_matching_billing_address
-        expect(_checkout.errors[:billing_address]).not_to be_empty
-      end
-
-      context "with alternate address format" do
-        it "sets an error for the billing_address" do
-          _checkout = FactoryGirl.build(:affirm_checkout, billing_address_mismatch: true, alternate_billing_address_format: true)
-          _checkout.check_matching_billing_address
-          expect(_checkout.errors[:billing_address]).not_to be_empty
-        end
-      end
-
-
-      context "with a name.full instead of first/last" do
-        it "sets an error for the billing_address" do
-          _checkout = FactoryGirl.build(:affirm_checkout, billing_address_mismatch: true, billing_address_full_name: true)
-          _checkout.check_matching_billing_address
-          expect(_checkout.errors[:billing_address]).not_to be_empty
-        end
-      end
-    end
-  end
-
-
 
   describe "#check_matching_shipping_address" do
     context "with a matching shipping address" do
@@ -157,25 +95,6 @@ describe Spree::AffirmCheckout do
         _checkout = FactoryGirl.build(:affirm_checkout, shipping_address_mismatch: true)
         _checkout.check_matching_shipping_address
         expect(_checkout.errors[:shipping_address]).not_to be_empty
-      end
-    end
-  end
-
-
-  describe "#check_matching_billing_email" do
-    context "with a matching billing email" do
-      it "does not set an error for the billing_email" do
-        valid_checkout.check_matching_billing_email
-        expect(valid_checkout.errors[:billing_email]).to be_empty
-      end
-    end
-
-
-    context "with a mismatched billing email" do
-      it "adds an error for billing_email" do
-        _checkout = FactoryGirl.build(:affirm_checkout, billing_email_mismatch: true)
-        _checkout.check_matching_billing_email
-        expect(_checkout.errors[:billing_email]).not_to be_empty
       end
     end
   end


### PR DESCRIPTION
### What
[CASH-535]

### Why
The new Single Page Checkout doesn't support billing address.
And that's why the `spree_affirm` gem threw exceptions, especially during the validation (`check_matching_billing_address` method).



[CASH-535]: https://framebridge.atlassian.net/browse/CASH-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ