### PR TITLE
Fix loading ActiveMerchant Billing

### DIFF
--- a/lib/spree_affirm/engine.rb
+++ b/lib/spree_affirm/engine.rb
@@ -1,3 +1,5 @@
+require_relative '../active_merchant/billing/affirm'
+
 module SpreeAffirm
   class Engine < Rails::Engine
     require 'spree/core'


### PR DESCRIPTION
We recently got some errors, where Affirm payment gateway references `ActiveMerchant::Billing::Affirm` and the constant can't be found. This happens in environments where eager loading classes is enabled. I added an explicit require, to make sure that the class is loaded.